### PR TITLE
feat:管理者用トップ画面・ユーザ一覧機能追加

### DIFF
--- a/apps/home/views.py
+++ b/apps/home/views.py
@@ -5,7 +5,11 @@ from django.contrib import messages
 # トップ画面
 @login_required
 def index_view(request):
-    return render(request, 'home/index.html')
+
+    if request.user.is_staff == True:
+        return render(request, 'home/admin.html')
+    else:
+        return render(request, 'home/index.html')
 
 # アカウント編集画面
 @login_required

--- a/apps/user/urls.py
+++ b/apps/user/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('signup/', views.SignupView.as_view(), name="signup"),
     path('login/', views.LoginView.as_view(), name="login"),
     path('logout/', views.LogoutView.as_view(), name="logout"),
+    path('userlist/', views.userlist_view, name="userlist"),
 ]

--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -1,8 +1,11 @@
+from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login, authenticate
 from django.views.generic import TemplateView, CreateView
 from django.contrib.auth.views import LoginView as BaseLoginView, LogoutView as BaseLogoutView
 from django.urls import reverse_lazy
 from .forms import SignUpForm, LoginForm
+from .models import User
 
 # ユーザー登録ビュー
 class SignupView(CreateView):
@@ -27,3 +30,12 @@ class LoginView(BaseLoginView):
 # ユーザーログアウトビュー
 class LogoutView(BaseLogoutView):
     success_url = reverse_lazy("user:login")
+
+
+# ユーザ一覧画面
+@login_required
+def userlist_view(request):
+
+    # ユーザテーブルから全ユーザ取得(作成日時の降順)
+    users = User.objects.all().order_by('-created_at')
+    return render(request, 'user/userlist.html', {'users': users})

--- a/static/css/stylesheets.css
+++ b/static/css/stylesheets.css
@@ -242,6 +242,13 @@ header {
     font-weight: bold;
 }
 
+.center_item{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
 
 /* 問題実施画面 */
 .question-box {

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,32 +37,33 @@
     
         </header>
 
-        <!-- ログインしている場合のみ表示 -->
-        {% if user.is_authenticated %}
-
             <div class="user_info">
-                ユーザ名：{{ user.name }}
 
-                <!-- アカウント編集 -->
-                <a href="{% url 'home:account' %}">
-                    <img src="{% static 'images/user_edit.png' %}" width="30" height="30" class="account_icon">
-                </a>
-        
-                <!-- レベルとアイコン表示（レベルに応じてアイコンを出し分け） -->
-                　　　Lv.{{ user.level }}　
-                {% if user.level == 1 %}
-                    <img src="{% static 'images/level1.png' %}" width="55" height="55" class="chara_icon">
-                {% elif user.level == 2 %}
-                    <img src="{% static 'images/level2.png' %}" width="55" height="55" class="chara_icon">
-                {% elif user.level == 3 %}
-                    <img src="{% static 'images/level3.png' %}" width="55" height="55" class="chara_icon">
-                {% elif user.level == 4 %}
-                    <img src="{% static 'images/level4.png' %}" width="55" height="55" class="chara_icon">
-                {% elif user.level == 5 %}
-                    <img src="{% static 'images/level5.png' %}" width="55" height="55" class="chara_icon">
-                {% endif %}            
+                <!-- ログイン済み、かつ管理者でない場合のみ表示 -->
+                {% if user.is_authenticated and not user.is_staff %}
+
+                    ユーザ名：{{ user.name }}
+
+                    <!-- アカウント編集 -->
+                    <a href="{% url 'home:account' %}">
+                        <img src="{% static 'images/user_edit.png' %}" width="30" height="30" class="account_icon">
+                    </a>
+            
+                    <!-- レベルとアイコン表示（レベルに応じてアイコンを出し分け） -->
+                    　　　Lv.{{ user.level }}　
+                    {% if user.level == 1 %}
+                        <img src="{% static 'images/level1.png' %}" width="55" height="55" class="chara_icon">
+                    {% elif user.level == 2 %}
+                        <img src="{% static 'images/level2.png' %}" width="55" height="55" class="chara_icon">
+                    {% elif user.level == 3 %}
+                        <img src="{% static 'images/level3.png' %}" width="55" height="55" class="chara_icon">
+                    {% elif user.level == 4 %}
+                        <img src="{% static 'images/level4.png' %}" width="55" height="55" class="chara_icon">
+                    {% elif user.level == 5 %}
+                        <img src="{% static 'images/level5.png' %}" width="55" height="55" class="chara_icon">
+                    {% endif %}            
+                {% endif %}
             </div>
-        {% endif %}
 
         {% block content %}{% endblock content %}
     </body>

--- a/templates/home/admin.html
+++ b/templates/home/admin.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}トップ{% endblock %}
+
+{% block content %}
+
+    <div class="container">
+        <div class="box">
+            <p>問題管理</p>
+            <a href="{% url 'question:index' %}">
+                <button class="button_home">問題一覧</button>
+            </a>
+            <a href="{% url 'question:create' %}">
+                <button class="button_home">問題作成</button>
+            </a>
+        </div>
+        <div class="box">
+            <p>各種管理</p>
+            <a href="{% url 'user:userlist' %}">
+                <button class="button_home">ユーザ一覧</button>
+            </a>
+
+            <a href="">
+                <button class="button_home">各種設定</button>
+            </a>
+
+        </div>
+    </div>
+
+{% endblock content %}

--- a/templates/question/index.html
+++ b/templates/question/index.html
@@ -47,5 +47,12 @@
                 {% endfor %}
             </tbody>
         </table>
+
+        <div class="center_item">
+            <a href="{% url 'home:index' %}">
+                <button class="button_return">トップページに戻る</button>
+            </a>
+        </div>
+
     </div>
 {% endblock content %}

--- a/templates/user/userlist.html
+++ b/templates/user/userlist.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block title %}ユーザ一覧{% endblock %}
+
+{% block content %}
+
+    <div class="incorrect_container">
+
+        <h1>ユーザ一覧</h1>
+
+        <table>
+            <thead>
+                <tr>
+                    <th width="80px">ユーザ名</th>
+                    <th width="200px">メールアドレス</th>
+                    <th width="150px">作成日時</th>
+                    <th width="60px">管理者権限</th>
+                    <th width="50px">削除</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                    <tr>
+                        <td class="td_item_left">{{ user.name }}</td>
+                        <td class="td_item_left">{{ user.email }}</td>
+                        <td>{{ user.created_at|date:"Y年n月j日 G時i分" }}</td>
+                        <td>{{ user.is_staff }}</td>
+                        <td>
+                            <a href="#" class="button_delete" onclick="return confirm('このユーザを削除してもよろしいですか？');">
+                                削除
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <a href="{% url 'home:index' %}">
+            <button class="button_return">トップページに戻る</button>
+        </a>
+
+    </div>
+{% endblock content %}
+


### PR DESCRIPTION
管理者用トップ画面とユーザ一覧機能を追加しました。

＜補足＞
・「is_staff」がTrueのユーザがログインすると、管理者用トップ画面に遷移します。
・「is_staff」はデフォルトでFalseなので、Trueへの変更はDBを直接修正してください。
・「is_staff」がTrueのユーザは、ヘッダー部分の「アカウント名」「レベル」「アイコン」を非表示にしています。
・管理者用トップ画面にあるメニューのうち、「各種設定」のみ未実装です。
　※今後の拡張性を踏まえ、メニューだけ用意（ハッカソン期間内での実装予定は無し）
